### PR TITLE
feat: 결혼식 축의금 액수 결정을 위한 질문지 조회 API 개발 #2

### DIFF
--- a/backend/src/main/java/com/kkk/kkk/config/DataInitializer.java
+++ b/backend/src/main/java/com/kkk/kkk/config/DataInitializer.java
@@ -1,0 +1,73 @@
+package com.kkk.kkk.config;
+
+import com.kkk.kkk.domain.Answer;
+import com.kkk.kkk.domain.Question;
+import com.kkk.kkk.domain.Topic;
+import com.kkk.kkk.repository.TopicRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+public class DataInitializer implements CommandLineRunner {
+
+    private final TopicRepository topicRepository;
+
+    public DataInitializer(TopicRepository topicRepository) {
+        this.topicRepository = topicRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        Topic topic = new Topic("AI 판사가 결정하는 당신의 결혼식 축의금!", "wedding-gift");
+
+        Question question1 = new Question("우리, 얼마나 밀착 중이야?", topic);
+        question1.getAnswers().addAll(Arrays.asList(
+                new Answer("거의 매일 얼굴 보는 사이", question1),
+                new Answer("한 달에 한 번은 꼭 보는 사이", question1),
+                new Answer("반기에 한 번, 마치 크리스마스처럼", question1),
+                new Answer("특별한 날에만 깜짝 등장", question1),
+                new Answer("그냥 풍경 같은 존재", question1)
+        ));
+
+        Question question2 = new Question("이 친구의 생일은 언제지?", topic);
+        question2.getAnswers().addAll(Arrays.asList(
+                new Answer("케이크를 준비하는 날!", question2),
+                new Answer("한 달 전부터 준비해", question2),
+                new Answer("페이스북이 알려줘", question2),
+                new Answer("생일이 있었나...?", question2),
+                new Answer("그냥 지나가는 또 하루", question2)
+        ));
+
+        Question question3 = new Question("결혼 소식을 들었을 때, 너의 첫 반응은?", topic);
+        question3.getAnswers().addAll(Arrays.asList(
+                new Answer("이미 예견된 미래", question3),
+                new Answer("와! 정말 축하해!", question3),
+                new Answer("헉, 진짜? 실화야?", question3),
+                new Answer("결혼이 무슨 색깔이야?", question3)
+        ));
+
+        Question question4 = new Question("우리 관계를 음식에 비유한다면?", topic);
+        question4.getAnswers().addAll(Arrays.asList(
+                new Answer("따뜻한 수프 같은 존재", question4),
+                new Answer("간간히 생각나는 디저트", question4),
+                new Answer("강렬한 매운맛 같은 인연", question4),
+                new Answer("가끔 필요한 소금 같은 존재", question4),
+                new Answer("음... 맛보지 않은 새로운 메뉴?", question4)
+        ));
+
+        Question question5 = new Question("결혼식 참석, 내 마음은 어때?", topic);
+        question5.getAnswers().addAll(Arrays.asList(
+                new Answer("결혼식? 거기에 내가 빠질 수 없지!", question5),
+                new Answer("친구 따라 강남 가기", question5),
+                new Answer("마음은 여기저기", question5),
+                new Answer("관심 밖의 이야기", question5)
+        ));
+
+        topic.getQuestions().addAll(Arrays.asList(question1, question2, question3, question4, question5));
+
+        topicRepository.save(topic);
+    }
+}
+

--- a/backend/src/main/java/com/kkk/kkk/controller/WeddingGiftController.java
+++ b/backend/src/main/java/com/kkk/kkk/controller/WeddingGiftController.java
@@ -1,0 +1,31 @@
+package com.kkk.kkk.controller;
+
+import com.kkk.kkk.dto.QuestionnaireResponseDto;
+import com.kkk.kkk.service.WeddingGiftService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@CrossOrigin(origins = "*")
+@RestController
+@RequestMapping("/api")
+public class WeddingGiftController {
+
+    private final WeddingGiftService weddingGiftService;
+
+    @Autowired
+    public WeddingGiftController(WeddingGiftService weddingGiftService) {
+        this.weddingGiftService = weddingGiftService;
+    }
+
+    @GetMapping("/wedding-gift")
+    public ResponseEntity<?> getWeddingGiftQuestionnaire() {
+        QuestionnaireResponseDto questionnaire = weddingGiftService.getWeddingGiftQuestionnaire();
+        if (questionnaire == null || questionnaire.getQuestions().isEmpty()) {
+            return new ResponseEntity<>("데이터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        } else {
+            return ResponseEntity.ok(questionnaire);
+        }
+    }
+}

--- a/backend/src/main/java/com/kkk/kkk/domain/Answer.java
+++ b/backend/src/main/java/com/kkk/kkk/domain/Answer.java
@@ -1,0 +1,33 @@
+package com.kkk.kkk.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Answer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String content;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Question question;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Question getQuestion() {
+        return question;
+    }
+
+    public Answer(String content, Question question) {
+        this.content = content;
+        this.question = question;
+    }
+
+    public Answer() {
+    }
+}

--- a/backend/src/main/java/com/kkk/kkk/domain/Question.java
+++ b/backend/src/main/java/com/kkk/kkk/domain/Question.java
@@ -1,0 +1,28 @@
+package com.kkk.kkk.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+public class Question {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String title;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Topic topic;
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Answer> answers = new ArrayList<>();
+
+    public Question() {}
+
+    public Question(String title, Topic topic) {
+        this.title = title;
+        this.topic = topic;
+    }
+
+}

--- a/backend/src/main/java/com/kkk/kkk/domain/Topic.java
+++ b/backend/src/main/java/com/kkk/kkk/domain/Topic.java
@@ -1,0 +1,26 @@
+package com.kkk.kkk.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+public class Topic {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String keyword;
+    private String title;
+    @OneToMany(mappedBy = "topic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Question> questions = new ArrayList<>();
+
+    public Topic(String title, String keyword) {
+        this.title = title;
+        this.keyword = keyword;
+    }
+    public Topic() {}
+
+}

--- a/backend/src/main/java/com/kkk/kkk/dto/AnswerDto.java
+++ b/backend/src/main/java/com/kkk/kkk/dto/AnswerDto.java
@@ -1,0 +1,21 @@
+package com.kkk.kkk.dto;
+
+public class AnswerDto {
+    private Long id;   // 답변의 고유 식별자
+    private String text; // 답변의 내용
+
+    private AnswerDto() {}
+
+    public AnswerDto(Long id, String text) {
+        this.id = id;
+        this.text = text;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/backend/src/main/java/com/kkk/kkk/dto/QuestionDto.java
+++ b/backend/src/main/java/com/kkk/kkk/dto/QuestionDto.java
@@ -1,0 +1,28 @@
+package com.kkk.kkk.dto;
+
+import java.util.List;
+
+public class QuestionDto {
+    private Long id;
+    private String question;
+    private List<AnswerDto> answers;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public List<AnswerDto> getAnswers() {
+        return answers;
+    }
+
+    public QuestionDto(Long id, String question, List<AnswerDto> answers) {
+        this.id = id;
+        this.question = question;
+        this.answers = answers;
+    }
+
+}

--- a/backend/src/main/java/com/kkk/kkk/dto/QuestionnaireResponseDto.java
+++ b/backend/src/main/java/com/kkk/kkk/dto/QuestionnaireResponseDto.java
@@ -1,0 +1,24 @@
+package com.kkk.kkk.dto;
+
+import java.util.List;
+
+public class QuestionnaireResponseDto {
+    private String topic;
+    private List<QuestionDto> questions;
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public List<QuestionDto> getQuestions() {
+        return questions;
+    }
+
+    public void setQuestions(List<QuestionDto> questions) {
+        this.questions = questions;
+    }
+}

--- a/backend/src/main/java/com/kkk/kkk/exception/TopicNotFoundException.java
+++ b/backend/src/main/java/com/kkk/kkk/exception/TopicNotFoundException.java
@@ -1,0 +1,8 @@
+package com.kkk.kkk.exception;
+
+public class TopicNotFoundException extends RuntimeException {
+
+    public TopicNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/kkk/kkk/repository/AnswerRepository.java
+++ b/backend/src/main/java/com/kkk/kkk/repository/AnswerRepository.java
@@ -1,0 +1,8 @@
+package com.kkk.kkk.repository;
+
+import com.kkk.kkk.domain.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}
+

--- a/backend/src/main/java/com/kkk/kkk/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/kkk/kkk/repository/QuestionRepository.java
@@ -1,0 +1,8 @@
+package com.kkk.kkk.repository;
+
+import com.kkk.kkk.domain.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}
+

--- a/backend/src/main/java/com/kkk/kkk/repository/TopicRepository.java
+++ b/backend/src/main/java/com/kkk/kkk/repository/TopicRepository.java
@@ -1,0 +1,9 @@
+package com.kkk.kkk.repository;
+
+import com.kkk.kkk.domain.Topic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface TopicRepository extends JpaRepository<Topic, Long> {
+    Topic findByKeyword(String keyword);
+}

--- a/backend/src/main/java/com/kkk/kkk/service/WeddingGiftService.java
+++ b/backend/src/main/java/com/kkk/kkk/service/WeddingGiftService.java
@@ -1,0 +1,51 @@
+package com.kkk.kkk.service;
+
+import com.kkk.kkk.domain.Answer;
+import com.kkk.kkk.domain.Question;
+import com.kkk.kkk.domain.Topic;
+import com.kkk.kkk.dto.AnswerDto;
+import com.kkk.kkk.dto.QuestionDto;
+import com.kkk.kkk.dto.QuestionnaireResponseDto;
+import com.kkk.kkk.exception.TopicNotFoundException;
+import com.kkk.kkk.repository.TopicRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class WeddingGiftService {
+
+    private final TopicRepository topicRepository;
+
+    @Autowired
+    public WeddingGiftService(TopicRepository topicRepository) {
+        this.topicRepository = topicRepository;
+    }
+
+    public QuestionnaireResponseDto getWeddingGiftQuestionnaire() {
+        String keyword = "wedding-gift";
+        Topic topic = topicRepository.findByKeyword(keyword);
+
+        if (topic == null) {
+            throw new TopicNotFoundException("주제를 찾을 수 없습니다: " + keyword);
+        }
+
+        List<QuestionDto> questions = new ArrayList<>();
+        for (Question question : topic.getQuestions()) {
+            List<AnswerDto> answers = new ArrayList<>();
+            for (Answer answer : question.getAnswers()) {
+                answers.add(new AnswerDto(answer.getId(), answer.getContent()));
+            }
+            questions.add(new QuestionDto(question.getId(), question.getTitle(), answers));
+        }
+
+        QuestionnaireResponseDto questionnaireResponseDto = new QuestionnaireResponseDto();
+        questionnaireResponseDto.setTopic(topic.getTitle());
+        questionnaireResponseDto.setQuestions(questions);
+        return questionnaireResponseDto;
+    }
+
+}


### PR DESCRIPTION
## 요약
결혼식 축의금 액수 결정을 위한 질문지 조회 API 개발

## 변경 내용 
- Topic, Question, Answer 도메인 모델 생성
- Repository 인터페이스 추가(TopicRepository, QuestionRepository, AnswerRepository)
- 초기 데이터 설정을 위한 DataInitializer 컴포넌트 구현
- 설문조사 로직을 처리하는 WeddingGiftService 서비스 계층 추가
- 사용자의 설문조사 요청을 처리하는 WeddingGiftController 컨트롤러 계층 구현
- DTO(AnswerDto, QuestionDto, QuestionnaireResponseDto)를 통한 데이터 전송 객체 설계
- 예외 처리를 위한 TopicNotFoundException 추가


## 이슈 번호 또는 링크
Closes #2